### PR TITLE
feat: add aggregator & access control for verifyRequest

### DIFF
--- a/src/templates/CoprocessorTemplate.sol
+++ b/src/templates/CoprocessorTemplate.sol
@@ -15,7 +15,8 @@
 //  d8'        `8b    88     88,     88          88,    ,88    `8b,d8'    "8b,   ,aa  88
 // d8'          `8b  8888    "Y888   88888888888 `"8bbdP"Y8      Y88'      `"Ybbd8"'  88
 //                                                               d8'
-//
+//                                                              d8'
+
 pragma solidity =0.8.26;
 
 import {EnumerableSetUpgradeable} from "@openzeppelin-upgrades/contracts/utils/structs/EnumerableSetUpgradeable.sol";


### PR DESCRIPTION
## Description
- Adds `aggregator` variable and `setAggregator` function, restricted to the owner.
- Restricts the `verifyRequest` function to only be callable by the aggregator.
- Adds NatSpec comments for better documentation.
